### PR TITLE
[slack] Update resource endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ $ perceval rss 'https://blog.bitergia.com/feed/'
 ```
 
 ### Slack
+
+Slack backend requires an API token for authentication. Slack apps can be
+used to generate and configure this API token. The scopes required by a Slack
+app for the backend are `channels:history`, `channels:read` and `users:read`.
+To know more about Slack apps and its integration please refer the
+[Slack apps documentation](https://api.slack.com/start/overview).
+For more information about the scopes required by a Slack app please refer the
+[Scopes and permissions documentation](https://api.slack.com/scopes).
+
+The following [script](https://gist.github.com/valeriocos/de31324625a3fab32449cf5d43b24075)
+can also be used to generate an OAuth2 token to access the Slack API.
+
 ```
 $ perceval slack C0001 --from-date 2016-01-12 -t abcedefghijk
 ```

--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -61,7 +61,7 @@ class Slack(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.9.0'
+    version = '0.9.1'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -302,9 +302,9 @@ class SlackClient(HttpClient):
     URL = urijoin(SLACK_URL, 'api', '%(resource)s')
 
     AUTHORIZATION_HEADER = 'Authorization'
-    RCONVERSATION_INFO = 'conversations.members'
-    RCHANNEL_INFO = 'channels.info'
-    RCHANNEL_HISTORY = 'channels.history'
+    RCONVERSATION_MEMBERS = 'conversations.members'
+    RCONVERSATION_INFO = 'conversations.info'
+    RCONVERSATION_HISTORY = 'conversations.history'
     RUSER_INFO = 'users.info'
 
     PCHANNEL = 'channel'
@@ -327,7 +327,7 @@ class SlackClient(HttpClient):
         """
         members = 0
 
-        resource = self.RCONVERSATION_INFO
+        resource = self.RCONVERSATION_MEMBERS
 
         params = {
             self.PCHANNEL: conversation,
@@ -348,7 +348,7 @@ class SlackClient(HttpClient):
     def channel_info(self, channel):
         """Fetch information about a channel."""
 
-        resource = self.RCHANNEL_INFO
+        resource = self.RCONVERSATION_INFO
 
         params = {
             self.PCHANNEL: channel,
@@ -361,7 +361,7 @@ class SlackClient(HttpClient):
     def history(self, channel, oldest=None, latest=None):
         """Fetch the history of a channel."""
 
-        resource = self.RCHANNEL_HISTORY
+        resource = self.RCONVERSATION_HISTORY
 
         params = {
             self.PCHANNEL: channel,

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -44,11 +44,11 @@ from perceval.backends.core.slack import (logger,
 from base import TestCaseBackendArchive
 
 
-SLACK_API_URL = 'https://slack.com/api'
-SLACK_CHANNEL_INFO_URL = SLACK_API_URL + '/channels.info'
-SLACK_CHANNEL_HISTORY_URL = SLACK_API_URL + '/channels.history'
-SLACK_CONVERSATION_MEMBERS = SLACK_API_URL + '/conversations.members'
-SLACK_USER_INFO_URL = SLACK_API_URL + '/users.info'
+SLACK_API_URL = 'https://slack.com/api/'
+SLACK_CHANNEL_INFO_URL = SLACK_API_URL + SlackClient.RCONVERSATION_INFO
+SLACK_CHANNEL_HISTORY_URL = SLACK_API_URL + SlackClient.RCONVERSATION_HISTORY
+SLACK_CONVERSATION_MEMBERS = SLACK_API_URL + SlackClient.RCONVERSATION_MEMBERS
+SLACK_USER_INFO_URL = SLACK_API_URL + SlackClient.RUSER_INFO
 
 
 def read_file(filename, mode='r'):
@@ -703,7 +703,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/conversations.members')
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_MEMBERS)
 
         for i in range(len(expected)):
             self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), http_requests[i].headers._headers)
@@ -727,7 +727,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/channels.info')
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_INFO)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 
@@ -754,7 +754,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/channels.history')
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_HISTORY)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 
@@ -781,7 +781,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/channels.history')
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_HISTORY)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 
@@ -804,7 +804,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/users.info')
+        self.assertRegex(req.path, SlackClient.RUSER_INFO)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 


### PR DESCRIPTION
This commit updates the resource endpoints
to fetch the messages and information of a
channel.
The tests have been updated accordingly.
The backend version is now 0.9.1

Signed-off-by: Animesh Kumar <animuz111@gmail.com>